### PR TITLE
Single match data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ activate
 .idea
 .ipynb_checkpoints
 **/.DS_Store
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ data/processed/test_stage_1.tsv: data/raw/test_stage_1.tsv.zip | data/processed
 data/processed/gap.tsv: data/raw/gap-coreference/gap-development.tsv data/raw/gap-coreference/gap-test.tsv
 	cp $< $@ && tail -n +2 $(word 2,$^) >> $@
 
-data/processed/single_match.tsv: data/processed/gap.tsv
+data/processed/single_match.tsv: data/processed/gap.tsv create_single_match_data.py
 	source activate && python create_single_match_data.py $< $@
 
 processdata: data/processed/test_stage_1.tsv data/processed/single_match.tsv

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,10 @@ data/processed/test_stage_1.tsv: data/raw/test_stage_1.tsv.zip | data/processed
 data/processed/gap.tsv: data/raw/gap-coreference/gap-development.tsv data/raw/gap-coreference/gap-test.tsv
 	cp $< $@ && tail -n +2 $(word 2,$^) >> $@
 
-processdata: data/processed/test_stage_1.tsv data/processed/gap.tsv
+data/processed/single_match.tsv: data/processed/gap.tsv
+	source activate && python create_single_match_data.py $< $@
+
+processdata: data/processed/test_stage_1.tsv data/processed/single_match.tsv
 
 # Clean commands
 

--- a/create_single_match_data.py
+++ b/create_single_match_data.py
@@ -21,4 +21,4 @@ if __name__=="__main__":
     gap_df = pd.read_csv(args['gap_tsv'], sep='\t')
 
     single_match_df = create_single_match_data(gap_df)
-    single_match_df.to_csv(args['outfile'], sep='\t')
+    single_match_df.to_csv(args['outfile'], sep='\t', index=False)

--- a/create_single_match_data.py
+++ b/create_single_match_data.py
@@ -1,11 +1,12 @@
 import pandas as pd
 
 def create_single_match_data(gap_df):
-    a_only = gap_df.drop(["B", "B-offset", "B-coref"], axis=1)
-    part1 = a_only.rename(columns={"A": "Name", "A-offset": "Name-offset", "A-coref": "Coref"})
-    b_only = gap_df.drop(["A", "A-offset", "A-coref"], axis=1)
-    part2 = b_only.rename(columns={"B": "Name", "B-offset": "Name-offset", "B-coref": "Coref"})
-    full_df = pd.concat([part1, part2])
+    part1 = gap_df.rename(columns={"A": "Name", "A-offset": "Name-offset", "A-coref": "Coref",
+                                   "B": "Other-name", "B-offset": "Other-offset", "B-coref": "Other-coref"})
+    part2 = gap_df.rename(columns={"B": "Name", "B-offset": "Name-offset", "B-coref": "Coref",
+                                   "A": "Other-name", "A-offset": "Other-offset", "A-coref": "Other-coref"})
+
+    full_df = pd.concat([part1, part2], sort=False)
 
     return full_df
 

--- a/create_single_match_data.py
+++ b/create_single_match_data.py
@@ -1,0 +1,23 @@
+import pandas as pd
+
+def create_single_match_data(gap_df):
+    a_only = gap_df.drop(["B", "B-offset", "B-coref"], axis=1)
+    part1 = a_only.rename(columns={"A": "Name", "A-offset": "Name-offset", "A-coref": "Coref"})
+    b_only = gap_df.drop(["A", "A-offset", "A-coref"], axis=1)
+    part2 = b_only.rename(columns={"B": "Name", "B-offset": "Name-offset", "B-coref": "Coref"})
+    full_df = pd.concat([part1, part2])
+
+    return full_df
+
+if __name__=="__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Change the GAP coreference data to single matching.")
+    parser.add_argument('gap_tsv', type=str, help='Path to the GAP tsv file')
+    parser.add_argument('outfile', type=str, help='Path to the output csv.')
+    args = vars(parser.parse_args())
+
+    gap_df = pd.read_csv(args['gap_tsv'], sep='\t')
+
+    single_match_df = create_single_match_data(gap_df)
+    single_match_df.to_csv(args['outfile'], sep='\t')


### PR DESCRIPTION
Add Python script to split GAP data to single matches.

The GAP data containss of 4000 rows with the following columns:
`ID	Text	Pronoun	Pronoun-offset	A	A-offset	A-coref	B	B-offset	B-coref	URL`

This script splits each row into two with the columns:
`ID	Text	Pronoun	Pronoun-offset	Name	Name-offset	Coref	URL`

The first row drops the B columns and the second row the A columns.
The columns ID, Text, Pronoun, Pronoun-Offset, and URL appear unchanged in both rows.
The remaining A and B columns are renamed to Name, Name-Offset, and Coref.

Finally we concatenate the new rows to create a data frame with 8000 rows.

Calling 'make' or 'make processdata' will generate the new file 'data/preprocessed/single_match.tsv'.