### PR TITLE
Add needed make dependency for gap-coreference files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ data/processed: | data/raw
 data/processed/test_stage_1.tsv: data/raw/test_stage_1.tsv.zip | data/processed
 	cd $(dir $@) && unzip ../../$< && chmod 0644 $(notdir $@) && touch $(notdir $@)
 
+data/raw/gap-coreference/gap-development.tsv: | data/raw/gap-coreference
+
+data/raw/gap-coreference/gap-test.tsv: | data/raw/gap-coreference
+
 data/processed/gap.tsv: data/raw/gap-coreference/gap-development.tsv data/raw/gap-coreference/gap-test.tsv
 	cp $< $@ && tail -n +2 $(word 2,$^) >> $@
 


### PR DESCRIPTION
Running make on a clean clone broke at some point because the ordering of the commands changed. This adds make dependencies so that the gap-coreference files are for sure downloaded before they're needed in the make rules.